### PR TITLE
Asssured Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Set these fields as a _Given_ call through the client or a HTTP request to the s
 
 If loading callbacks from a JSON file, the call [unmarshaller](pkg/assured/call.go) will attempt to read the resource field as a relative file, or else a quoted string, or else just a byte slice.
 
-To understand how rest assured is working behind the scenes, or to use rest assured as a standalone application you can run from a command line and use anywhere, or how to serve HTTPS traffic from rest assured, read the application [README](cmd/assured/README.md)
+To understand how rest assured is working behind the scenes, or to use rest assured as a standalone application you can run from a command line and use anywhere, or how to serve HTTPS traffic from rest assured, read the application [README](cmd/go-assured/README.md)
 
 ### Client
 

--- a/cmd/go-assured/README.md
+++ b/cmd/go-assured/README.md
@@ -31,7 +31,7 @@ You can specify a TLS cert/key to mock out HTTPS traffic using [mkcert](https://
 To stub out an assured call hit the following endpoint
 `/given/{path:.*}`
 
-The HTTP Method you use will be stored in the Assured Call
+The HTTP Method you use will be stored in the Assured Call unless you specify a `"Assured-Method": "[a-zA-Z]+"` HTTP Header.
 
 The Request Body, if present, will be stored in the Assured Call
 

--- a/cmd/go-assured/README.md
+++ b/cmd/go-assured/README.md
@@ -24,7 +24,7 @@ Usage of go-assured:
 
 To load in a default set of stubbed endpoints from a file, follow the [Preload API Reference](preload_reference.md) guide.
 
-You can specify a TLS cert/key to mock out HTTPS traffic. View the [docker-compose](../../build/docker-compose.yml) example to see how you can load TLS certs using [mkcert](https://github.com/FiloSottile/mkcert) self signed certs and mock HTTPS traffic.
+You can specify a TLS cert/key to mock out HTTPS traffic using [mkcert](https://github.com/FiloSottile/mkcert) self signed certs and mock HTTPS traffic.
 
 ## Stubbing
 
@@ -96,7 +96,7 @@ This endpoint returns a list of assured calls made against the matching Method/P
 
 ## Clearing
 
-To clear out the stubbed and made calls for a specific Method/Path, use the endpoint `/clear/{path:.*}`
+To clear out the stubbed and made calls for a specific Method/Path, use the endpoint DELETE `/clear/{path:.*}`
 _Including the HTTP Header `Assured-Callback-Key` will clear all callbacks associated with that key (independent of path)_
 
 To clear out all stubbed calls on the server, use the endpoint `/clear`

--- a/pkg/assured/bindings.go
+++ b/pkg/assured/bindings.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	AssuredStatus         = "Assured-Status"
+	AssuredMethod         = "Assured-Method"
 	AssuredDelay          = "Assured-Delay"
 	AssuredCallbackKey    = "Assured-Callback-Key"
 	AssuredCallbackTarget = "Assured-Callback-Target"
@@ -128,9 +129,14 @@ func (c *Client) createApplicationRouter() *mux.Router {
 // decodeAssuredCall converts an http request into an assured Call object
 func decodeAssuredCall(ctx context.Context, req *http.Request) (interface{}, error) {
 	urlParams := mux.Vars(req)
+	method := req.Method
+	if m := req.Header.Get(AssuredMethod); m != "" {
+		method = m
+	}
+
 	ac := Call{
 		Path:       urlParams["path"],
-		Method:     req.Method,
+		Method:     method,
 		StatusCode: http.StatusOK,
 	}
 

--- a/pkg/assured/bindings_test.go
+++ b/pkg/assured/bindings_test.go
@@ -191,6 +191,35 @@ func TestDecodeAssuredCallStatus(t *testing.T) {
 	require.True(t, decoded, "decode method was not hit")
 }
 
+func TestDecodeAssuredCallMethod(t *testing.T) {
+	decoded := false
+	expected := &Call{
+		Path:       "test/assured",
+		StatusCode: http.StatusOK,
+		Method:     http.MethodDelete,
+		Headers:    map[string]string{"Assured-Method": "DELETE"},
+		Query:      map[string]string{},
+	}
+	testDecode := func(resp http.ResponseWriter, req *http.Request) {
+		c, err := decodeAssuredCall(context.TODO(), req)
+
+		require.NoError(t, err)
+		require.Equal(t, expected, c)
+		decoded = true
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "/given/test/assured", nil)
+	require.NoError(t, err)
+	req.Header.Set("Assured-Method", "DELETE")
+
+	router := mux.NewRouter()
+	router.HandleFunc("/given/{path:.*}", testDecode).Methods(http.MethodGet)
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	require.True(t, decoded, "decode method was not hit")
+}
+
 func TestDecodeAssuredCallStatusFailure(t *testing.T) {
 	decoded := false
 	expected := &Call{


### PR DESCRIPTION
add an `Assured-Method` option to set the call's method other than that of the request.
fix documentation