### PR TITLE
V4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,12 +6,14 @@ jobs:
   test:
     name: test
     runs-on: ubuntu-latest
-    container: golang:1.19-alpine
-    env:
-      CGO_ENABLED: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: stable
+          check-latest: true
 
       - name: Test
         run: |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Jesse Michael
+Copyright (c) 2023 Jesse Michael
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To understand how rest assured is working behind the scenes, or to use rest assu
 ### Client
 
 ```go
-import ("github.com/jesse0michael/go-rest-assured/v3/pkg/assured")
+import ("github.com/jesse0michael/go-rest-assured/v4/pkg/assured")
 
 // Create and run a new Assured Client
 client := assured.NewClient()

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ To understand how rest assured is working behind the scenes, or to use rest assu
 ```go
 import ("github.com/jesse0michael/go-rest-assured/v4/pkg/assured")
 
-// Create and run a new Assured Client
-client := assured.NewClient()
+// Create and Serve a new Assured Client
+client := assured.NewClientServe()
 defer client.Close()
 ```
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19-alpine AS build
+FROM golang:1.21-alpine AS build
 
 # Copy project files
 WORKDIR /go/src

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,8 @@
 FROM golang:1.21-alpine AS build
 
+LABEL org.opencontainers.image.source "https://github.com/jesse0michael/go-rest-assurede"
+LABEL org.opencontainers.image.description "Docker image for the GO Rest Assured client to mock and validate your calls to REST API's"
+
 # Copy project files
 WORKDIR /go/src
 COPY go.mod .

--- a/cmd/go-assured/main.go
+++ b/cmd/go-assured/main.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	kitlog "github.com/go-kit/kit/log"
-	"github.com/jesse0michael/go-rest-assured/v3/pkg/assured"
+	"github.com/jesse0michael/go-rest-assured/v4/pkg/assured"
 )
 
 // Preload is the expected format for preloading assured endpoints through the go rest assured application

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jesse0michael/go-rest-assured/v4
 
-go 1.19
+go 1.21
 
 require (
 	github.com/go-kit/kit v0.10.0

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,16 @@ go 1.21
 
 require (
 	github.com/go-kit/kit v0.10.0
-	github.com/gorilla/handlers v1.5.0
+	github.com/google/uuid v1.3.1
+	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
-	github.com/pborman/uuid v1.2.1
-	github.com/stretchr/testify v1.6.1
+	github.com/stretchr/testify v1.8.4
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.0 // indirect
-	github.com/google/uuid v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jesse0michael/go-rest-assured/v3
+module github.com/jesse0michael/go-rest-assured/v4
 
 go 1.19
 

--- a/go.sum
+++ b/go.sum
@@ -85,12 +85,13 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
-github.com/gorilla/handlers v1.5.0 h1:4wjo3sf9azi99c8hTmyaxp9y5S+pFszsy3pP0rAw/lw=
-github.com/gorilla/handlers v1.5.0/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
+github.com/gorilla/handlers v1.5.1 h1:9lRY6j8DEeeBT10CvO9hGW0gmky0BprnvDI5vfhUHH4=
+github.com/gorilla/handlers v1.5.1/go.mod h1:t8XrUpc4KVXb7HGyJ4/cEnwQiaxrX/hz1Zv/4g96P1Q=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
@@ -185,8 +186,6 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
-github.com/pborman/uuid v1.2.1 h1:+ZZIw58t/ozdjRaXh/3awHfmWRbzYxJoAdNJxe/3pvw=
-github.com/pborman/uuid v1.2.1/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -236,8 +235,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
-github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
-github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
@@ -358,8 +357,8 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/assured/bindings.go
+++ b/pkg/assured/bindings.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	kithttp "github.com/go-kit/kit/transport/http"
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 )
 
@@ -22,15 +21,6 @@ const (
 	AssuredCallbackTarget = "Assured-Callback-Target"
 	AssuredCallbackDelay  = "Assured-Callback-Delay"
 )
-
-// Serve starts the Rest Assured client to begin listening on the application endpoints
-func (c *Client) Serve() error {
-	if c.tlsCertFile != "" && c.tlsKeyFile != "" {
-		return http.ServeTLS(c.listener, handlers.RecoveryHandler()(c.router), c.tlsCertFile, c.tlsKeyFile)
-	} else {
-		return http.Serve(c.listener, handlers.RecoveryHandler()(c.router))
-	}
-}
 
 // createApplicationRouter sets up the router that will handle all of the application routes
 func (c *Client) createApplicationRouter() *mux.Router {

--- a/pkg/assured/bindings.go
+++ b/pkg/assured/bindings.go
@@ -25,7 +25,6 @@ const (
 
 // Serve starts the Rest Assured client to begin listening on the application endpoints
 func (c *Client) Serve() error {
-	_ = c.logger.Log("message", "starting go rest assured", "port", c.Port)
 	if c.tlsCertFile != "" && c.tlsKeyFile != "" {
 		return http.ServeTLS(c.listener, handlers.RecoveryHandler()(c.router), c.tlsCertFile, c.tlsKeyFile)
 	} else {
@@ -54,7 +53,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.WrappedEndpoint(e.GivenEndpoint),
 			decodeAssuredCall,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(assuredMethods...)
 
@@ -64,7 +62,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.WrappedEndpoint(e.GivenCallbackEndpoint),
 			decodeAssuredCallback,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(assuredMethods...)
 
@@ -74,7 +71,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.WrappedEndpoint(e.WhenEndpoint),
 			decodeAssuredCall,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(assuredMethods...)
 
@@ -84,7 +80,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.WrappedEndpoint(e.VerifyEndpoint),
 			decodeAssuredCall,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(assuredMethods...)
 
@@ -94,7 +89,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.WrappedEndpoint(e.ClearEndpoint),
 			decodeAssuredCall,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(assuredMethods...)
 
@@ -104,7 +98,6 @@ func (c *Client) createApplicationRouter() *mux.Router {
 			e.ClearAllEndpoint,
 			decodeAssuredCall,
 			encodeAssuredCall,
-			kithttp.ServerErrorLogger(c.logger),
 			kithttp.ServerAfter(kithttp.SetResponseHeader("Access-Control-Allow-Origin", "*"))),
 	).Methods(http.MethodDelete)
 

--- a/pkg/assured/client.go
+++ b/pkg/assured/client.go
@@ -10,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/gorilla/mux"
-	"github.com/pborman/uuid"
 )
 
 // Client
@@ -85,7 +85,7 @@ func (c *Client) Given(calls ...Call) error {
 
 		// Create callbacks
 		callbacks := make([]*http.Request, len(call.Callbacks))
-		callbackKey := uuid.New()
+		callbackKey := uuid.NewString()
 		for i, callback := range call.Callbacks {
 			if callback.Target == "" {
 				return fmt.Errorf("cannot stub callback without target")
@@ -130,7 +130,6 @@ func (c *Client) Verify(method, path string) ([]Call, error) {
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(req)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failure to verify calls")

--- a/pkg/assured/client.go
+++ b/pkg/assured/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
@@ -30,7 +31,7 @@ func NewClient(opts ...Option) *Client {
 	var err error
 	c.listener, err = net.Listen("tcp", fmt.Sprintf(":%d", c.Options.Port))
 	if err != nil {
-		_ = c.logger.Log("error", err.Error())
+		slog.With("error", err, "port", c.Options.Port).Error("unable to create http listener")
 	}
 
 	c.Options.Port = c.listener.Addr().(*net.TCPAddr).Port

--- a/pkg/assured/client_test.go
+++ b/pkg/assured/client_test.go
@@ -17,6 +17,8 @@ import (
 
 func TestClient(t *testing.T) {
 	client := NewClient(WithPort(9091))
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	time.Sleep(time.Second)
 
 	url := client.URL()
@@ -116,6 +118,8 @@ func TestClientTLS(t *testing.T) {
 	}}
 	client := NewClient(WithTLS("testdata/localhost.pem", "testdata/localhost-key.pem"), WithPort(9092),
 		WithHTTPClient(insecureClient))
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	time.Sleep(1 * time.Second)
 
 	url := client.URL()
@@ -163,6 +167,8 @@ func TestClientCallbacks(t *testing.T) {
 		delayCalled = true
 	}))
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	time.Sleep(time.Second)
 
 	require.NoError(t, client.Given(Call{
@@ -203,7 +209,9 @@ func TestClientCallbacks(t *testing.T) {
 
 func TestClientClose(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
 	client2 := NewClient()
+	go func() { _ = client2.Serve() }()
 	time.Sleep(time.Second)
 
 	require.NotEqual(t, client.URL(), client2.URL())
@@ -228,6 +236,8 @@ func TestClientClose(t *testing.T) {
 
 func TestClientGivenNoMethod(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	time.Sleep(time.Second)
 
 	err := client.Given(Call{Path: "NoMethodMan"})
@@ -249,6 +259,8 @@ func TestClientGivenCallbackMissingTarget(t *testing.T) {
 		},
 	}
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 
 	err := client.Given(call)
 
@@ -264,6 +276,8 @@ func TestClientGivenCallbackBadMethod(t *testing.T) {
 		},
 	}
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 
 	err := client.Given(call)
 
@@ -273,6 +287,8 @@ func TestClientGivenCallbackBadMethod(t *testing.T) {
 
 func TestClientBadRequestFailure(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 
 	err := client.Given(Call{Method: "\"", Path: "goat/path"})
 
@@ -304,6 +320,7 @@ func TestClientBadRequestFailure(t *testing.T) {
 
 func TestClientVerifyHttpClientFailure(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
 	client.Close()
 
 	calls, err := client.Verify("GONE", "not/started")
@@ -315,6 +332,8 @@ func TestClientVerifyHttpClientFailure(t *testing.T) {
 
 func TestClientVerifyResponseFailure(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
 	}))
@@ -333,6 +352,8 @@ func TestClientVerifyResponseFailure(t *testing.T) {
 
 func TestClientVerifyBodyFailure(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_ = json.NewEncoder(w).Encode("ydob+dab")
@@ -352,6 +373,8 @@ func TestClientVerifyBodyFailure(t *testing.T) {
 
 func TestClientPathSanitization(t *testing.T) {
 	client := NewClient()
+	go func() { _ = client.Serve() }()
+	defer client.Close()
 	time.Sleep(time.Second)
 
 	require.NoError(t, client.Given(Call{Method: "GET", Path: "///yoyo/path///", StatusCode: http.StatusAccepted}))

--- a/pkg/assured/client_test.go
+++ b/pkg/assured/client_test.go
@@ -149,6 +149,12 @@ func TestClientTLS(t *testing.T) {
 	}, calls)
 }
 
+func TestClientInvalidPort(t *testing.T) {
+	client := NewClient(WithPort(-1))
+
+	require.Error(t, client.Serve())
+}
+
 func TestClientCallbacks(t *testing.T) {
 	httpClient := http.Client{}
 	called := false
@@ -235,8 +241,7 @@ func TestClientClose(t *testing.T) {
 }
 
 func TestClientGivenNoMethod(t *testing.T) {
-	client := NewClient()
-	go func() { _ = client.Serve() }()
+	client := NewClientServe()
 	defer client.Close()
 	time.Sleep(time.Second)
 

--- a/pkg/assured/client_test.go
+++ b/pkg/assured/client_test.go
@@ -117,7 +117,6 @@ func TestClientTLS(t *testing.T) {
 	client := NewClient(WithTLS("testdata/localhost.pem", "testdata/localhost-key.pem"), WithPort(9092),
 		WithHTTPClient(insecureClient))
 	time.Sleep(1 * time.Second)
-	require.Len(t, client.Errc, 0)
 
 	url := client.URL()
 	require.Equal(t, "https://localhost:9092/when", url)

--- a/pkg/assured/endpoints_test.go
+++ b/pkg/assured/endpoints_test.go
@@ -2,19 +2,16 @@ package assured
 
 import (
 	"context"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	kitlog "github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewAssuredEndpoints(t *testing.T) {
 	expected := &AssuredEndpoints{
-		logger:         kitlog.NewNopLogger(),
 		httpClient:     http.DefaultClient,
 		assuredCalls:   NewCallStore(),
 		madeCalls:      NewCallStore(),
@@ -120,7 +117,6 @@ func TestGivenCallbackEndpointSuccess(t *testing.T) {
 
 func TestWhenEndpointSuccess(t *testing.T) {
 	endpoints := &AssuredEndpoints{
-		logger:         DefaultOptions.logger,
 		assuredCalls:   fullAssuredCalls,
 		madeCalls:      NewCallStore(),
 		callbackCalls:  NewCallStore(),
@@ -153,7 +149,6 @@ func TestWhenEndpointSuccess(t *testing.T) {
 
 func TestWhenEndpointSuccessTrackingDisabled(t *testing.T) {
 	endpoints := &AssuredEndpoints{
-		logger:         DefaultOptions.logger,
 		assuredCalls:   fullAssuredCalls,
 		madeCalls:      NewCallStore(),
 		callbackCalls:  NewCallStore(),
@@ -194,7 +189,6 @@ func TestWhenEndpointSuccessCallbacks(t *testing.T) {
 	call := testCallback()
 	call.Headers[AssuredCallbackTarget] = testServer.URL
 	endpoints := &AssuredEndpoints{
-		logger:     DefaultOptions.logger,
 		httpClient: http.DefaultClient,
 		assuredCalls: &CallStore{
 			data: map[string][]*Call{"GET:test/assured": {assured}},
@@ -227,7 +221,6 @@ func TestWhenEndpointSuccessDelayed(t *testing.T) {
 	call.Headers[AssuredCallbackTarget] = testServer.URL
 	call.Headers[AssuredCallbackDelay] = "4"
 	endpoints := &AssuredEndpoints{
-		logger:     DefaultOptions.logger,
 		httpClient: http.DefaultClient,
 		assuredCalls: &CallStore{
 			data: map[string][]*Call{"GET:test/assured": {assured}},
@@ -313,7 +306,6 @@ func TestVerifyEndpointTrackingDisabled(t *testing.T) {
 
 func TestClearEndpointSuccess(t *testing.T) {
 	endpoints := &AssuredEndpoints{
-		logger:         kitlog.NewLogfmtLogger(io.Discard),
 		assuredCalls:   fullAssuredCalls,
 		madeCalls:      fullAssuredCalls,
 		callbackCalls:  NewCallStore(),
@@ -347,7 +339,6 @@ func TestClearEndpointSuccess(t *testing.T) {
 
 func TestClearEndpointSuccessCallback(t *testing.T) {
 	endpoints := &AssuredEndpoints{
-		logger:       kitlog.NewLogfmtLogger(io.Discard),
 		assuredCalls: fullAssuredCalls,
 		madeCalls:    NewCallStore(),
 		callbackCalls: &CallStore{
@@ -370,7 +361,6 @@ func TestClearEndpointSuccessCallback(t *testing.T) {
 
 func TestClearAllEndpointSuccess(t *testing.T) {
 	endpoints := &AssuredEndpoints{
-		logger:         kitlog.NewLogfmtLogger(io.Discard),
 		assuredCalls:   fullAssuredCalls,
 		madeCalls:      fullAssuredCalls,
 		callbackCalls:  fullAssuredCalls,

--- a/pkg/assured/options.go
+++ b/pkg/assured/options.go
@@ -1,7 +1,6 @@
 package assured
 
 import (
-	"context"
 	"net/http"
 
 	kitlog "github.com/go-kit/kit/log"
@@ -19,10 +18,6 @@ type Option func(*Options)
 
 // Options can be used to configure the rest assured client.
 type Options struct {
-	// ctx to pass to the rest assured server
-	ctx    context.Context
-	cancel context.CancelFunc //nolint:structcheck
-
 	// logger used by the rest assured client
 	logger kitlog.Logger
 
@@ -43,13 +38,6 @@ type Options struct {
 
 	// trackMadeCalls toggles storing the requests made against the rest assured server. Defaults to true.
 	trackMadeCalls bool
-}
-
-// WithContext sets the context option.
-func WithContext(c context.Context) Option {
-	return func(o *Options) {
-		o.ctx = c
-	}
 }
 
 // WithLogger sets the logger to be used.

--- a/pkg/assured/options.go
+++ b/pkg/assured/options.go
@@ -2,12 +2,9 @@ package assured
 
 import (
 	"net/http"
-
-	kitlog "github.com/go-kit/kit/log"
 )
 
 var DefaultOptions = Options{
-	logger:         kitlog.NewNopLogger(),
 	httpClient:     http.DefaultClient,
 	host:           "localhost",
 	trackMadeCalls: true,
@@ -18,9 +15,6 @@ type Option func(*Options)
 
 // Options can be used to configure the rest assured client.
 type Options struct {
-	// logger used by the rest assured client
-	logger kitlog.Logger
-
 	// httpClient used to interact with the rest assured server
 	httpClient *http.Client
 
@@ -38,13 +32,6 @@ type Options struct {
 
 	// trackMadeCalls toggles storing the requests made against the rest assured server. Defaults to true.
 	trackMadeCalls bool
-}
-
-// WithLogger sets the logger to be used.
-func WithLogger(l kitlog.Logger) Option {
-	return func(o *Options) {
-		o.logger = l
-	}
 }
 
 // WithHTTPClient sets the http client option.

--- a/pkg/assured/options_test.go
+++ b/pkg/assured/options_test.go
@@ -4,24 +4,14 @@ import (
 	"net/http"
 	"reflect"
 	"testing"
-
-	kitlog "github.com/go-kit/kit/log"
 )
 
 func Test_applyOptions(t *testing.T) {
-	log := kitlog.NewNopLogger()
 	tests := []struct {
 		name   string
 		option Option
 		want   Options
 	}{
-		{
-			name:   "with logger",
-			option: WithLogger(log),
-			want: Options{
-				logger: log,
-			},
-		},
 		{
 			name:   "with http client",
 			option: WithHTTPClient(*http.DefaultClient),

--- a/pkg/assured/options_test.go
+++ b/pkg/assured/options_test.go
@@ -1,7 +1,6 @@
 package assured
 
 import (
-	"context"
 	"net/http"
 	"reflect"
 	"testing"
@@ -11,19 +10,11 @@ import (
 
 func Test_applyOptions(t *testing.T) {
 	log := kitlog.NewNopLogger()
-	ctx := context.TODO()
 	tests := []struct {
 		name   string
 		option Option
 		want   Options
 	}{
-		{
-			name:   "with context",
-			option: WithContext(ctx),
-			want: Options{
-				ctx: ctx,
-			},
-		},
 		{
 			name:   "with logger",
 			option: WithLogger(log),


### PR DESCRIPTION
[feat: BREAKING CHANGE upgrade rest assured to v4](https://github.com/Jesse0Michael/go-rest-assured/commit/b1d6cc11e692952793fa6484e540e46fbb1df11a)
[feat: export Serve method to start http listener](https://github.com/Jesse0Michael/go-rest-assured/commit/f51f3a59951b2316282ef1f698ef40abd0742d6b)
Remove client context and error channel.
Rely on the caller of the package to appropriately call Serve
[chore: upgrade to go 1.21](https://github.com/Jesse0Michael/go-rest-assured/commit/e90797d9c77f661fb0e64d440bc17ff46d872b1e)
[feat: move to log/slog for logging](https://github.com/Jesse0Michael/go-rest-assured/commit/95e02aca5a8ce5a065d920e56973fb606ef62fbf)
[fix: use google/uuid package](https://github.com/Jesse0Michael/go-rest-assured/commit/b7c3d2dc4939665ab817df2419a28db4376abb08)
[test: Serve rest assured client in tests](https://github.com/Jesse0Michael/go-rest-assured/commit/1e3cf4c77878750d09cfb555f1e850b39d32c39a)
[chore: update license](https://github.com/Jesse0Michael/go-rest-assured/commit/9fe24e3f833ed6149c3bca072bd837ecd6934dde)
[feat: add NewClientServe function](https://github.com/Jesse0Michael/go-rest-assured/commit/556a0d8c1de5d351624f9f671d5841dfca51b1f3)
[build: add docker labels](https://github.com/Jesse0Michael/go-rest-assured/commit/c5dbe4cd14961de9fba0dccd6717cf7c8deda84d)


update the go rest assured package to be more flexible.
update dependencies and documentation
